### PR TITLE
Bugfix: fix nextAllBase losing the first remaining token

### DIFF
--- a/examples/ex-01.add.zig
+++ b/examples/ex-01.add.zig
@@ -53,7 +53,7 @@ pub fn main() !void {
     _ = try it.next();
     defer it.deinit();
 
-    // it.debug = true;
+    // it.debug(true);
 
     const args = try cmd.parseAlloc(&it, allocator);
     defer cmd.destory(&args, allocator);
@@ -68,8 +68,7 @@ pub fn main() !void {
             }
         },
         .remain => |_| {
-            // FIXME first num of remaining has been abandoned
-            const nums = try it.reinit(.{}).nextAllBase(allocator);
+            const nums = try it.nextAllBase(allocator);
             defer allocator.free(nums);
             for (nums) |s| {
                 const n = any(@TypeOf(sum), s) orelse {

--- a/examples/ex-mess.zig
+++ b/examples/ex-mess.zig
@@ -68,7 +68,7 @@ pub fn main() !void {
     // var it = try Iter.initLine("-vv --int 1 --bool t --lastc hi --word ok --3word a b c 1", null, .{});
     // var it = try Iter.initLine("a", null, .{});
     defer it.deinit();
-    // it.debug = true;
+    // it.debug(true);
 
     const args = cmd.parseAlloc(&it, allocator) catch |e| {
         std.debug.print("\nError => {}\n", .{e});
@@ -76,7 +76,7 @@ pub fn main() !void {
         std.process.exit(1);
     };
     defer cmd.destory(&args, allocator);
-    // it.debug = false;
+    // it.debug(false);
     std.debug.print("{}\n\n", .{args});
 
     switch (args.sub) {
@@ -90,8 +90,7 @@ pub fn main() !void {
 
     if ((try it.view()) != null) {
         std.debug.print("\nRemain command line input:\n\t", .{});
-        // const remain = try it.nextAllBase(allocator);
-        const remain = try it.reinit(.{}).nextAll(allocator);
+        const remain = try it.nextAllBase(allocator);
         defer allocator.free(remain);
         std.debug.print("{s}\n", .{remain});
     }

--- a/src/command.zig
+++ b/src/command.zig
@@ -236,7 +236,7 @@ pub const Command = struct {
             self.use_builtin_help = false;
         }
         if (short == null and long == null) {
-            @compileError("opt(Arg)<" ++ name ++ "> at least one of short or long is required");
+            @compileError("opt(Arg):" ++ name ++ " at least one of short or long is required");
         }
         if (short) |s| self.checkShort(s);
         if (long) |l| self.checkLong(l);
@@ -256,7 +256,7 @@ pub const Command = struct {
     ) *Self {
         self.checkOpt(name, config.short, config.long);
         if (T != bool and @typeInfo(T) != .Int) {
-            @compileError("opt<" ++ name ++ "> not accept " ++ @typeName(T));
+            @compileError("opt:" ++ name ++ " not accept " ++ @typeName(T));
         }
         var m: meta.Meta = .{ .name = name, .T = T, .help = config.help, .log = self.log };
         if (config.default) |d| {
@@ -316,11 +316,11 @@ pub const Command = struct {
         const info = @typeInfo(T);
         if (info == .Pointer) {
             if (info.Pointer.size != .Slice or !info.Pointer.is_const) {
-                @compileError("optArg<" ++ name ++ "> not accept " ++ @typeName(T));
+                @compileError("optArg:" ++ name ++ " not accept " ++ @typeName(T));
             }
             if (T != []const u8) {
                 if (config.default != null) {
-                    @compileError("optArg<" ++ name ++ "> not support default for Slice");
+                    @compileError("optArg:" ++ name ++ " not support default for Slice");
                 }
             }
         }
@@ -392,7 +392,7 @@ pub const Command = struct {
         },
     ) *Self {
         if (self.use_subCmd) |s| {
-            @compileError("posArg<" ++ name ++ "> not accept because subCmd<" ++ s ++ "> exist");
+            @compileError("posArg:" ++ name ++ " not accept because subCmd<" ++ s ++ "> exist");
         }
         self.checkName(name);
         var m: meta.Meta = .{ .name = name, .T = T, .help = config.help, .log = self.log };
@@ -765,7 +765,7 @@ pub const Command = struct {
                             if (!hitOpts.add(m.meta.name)) {
                                 if (m.meta.T != bool) break;
                                 if (self.log) |log| {
-                                    log("opt<{s}> repeat with {}", .{ m.meta.name, o });
+                                    log("opt:{s} repeat with {}", .{ m.meta.name, o });
                                 }
                                 return Error.RepeatOpt;
                             }
@@ -776,7 +776,7 @@ pub const Command = struct {
                     inline for (self._optArgs) |m| {
                         if (m.meta.isSlice() and allocator == null) {
                             if (self.log) |log| {
-                                log("optArg<{s}> allocator is required", .{m.meta.name});
+                                log("optArg:{s} allocator is required", .{m.meta.name});
                             }
                             return Error.Allocator;
                         }
@@ -785,7 +785,7 @@ pub const Command = struct {
                             if (!hitOpts.add(m.meta.name)) {
                                 if (m.meta.isSlice()) break;
                                 if (self.log) |log| {
-                                    log("optArg<{s}> repeat with {}", .{ m.meta.name, o });
+                                    log("optArg:{s} repeat with {}", .{ m.meta.name, o });
                                 }
                                 return Error.RepeatOpt;
                             }
@@ -810,7 +810,7 @@ pub const Command = struct {
                 if (!m.meta.isSlice() and !hitOpts.contain(m.meta.name)) {
                     if (self.log) |log| {
                         const u = comptime m.usage();
-                        log("optArg<{s}> is required, but not found {s}", .{ m.meta.name, u });
+                        log("optArg:{s} is required, but not found {s}", .{ m.meta.name, u });
                     }
                     return Error.MissingOptArg;
                 }

--- a/src/command.zig
+++ b/src/command.zig
@@ -749,7 +749,7 @@ pub const Command = struct {
 
         while (it.view() catch |e| return self.errCastIter(e)) |top| {
             switch (top) {
-                .Opt => |o| {
+                .opt => |o| {
                     var hit = false;
                     if (self.use_builtin_help) {
                         if (meta.hitOpt(Builtin.help, top)) {
@@ -798,7 +798,7 @@ pub const Command = struct {
                     }
                     return Error.UnknownOpt;
                 },
-                .PosArg, .Arg => {
+                .posArg, .arg => {
                     it.flag_termiantor = true;
                     break;
                 },
@@ -840,7 +840,7 @@ pub const Command = struct {
                 }
             }
             if (self.log) |log| {
-                log("Unknown subCmd {s}", .{(it.viewMust() catch unreachable).as_posArg().PosArg});
+                log("Unknown subCmd {s}", .{(it.viewMust() catch unreachable).as_posArg().posArg});
             }
             return Error.UnknownSubCmd;
         }
@@ -848,7 +848,7 @@ pub const Command = struct {
     }
 
     fn consume(self: Self, comptime s: []const u8, r: anytype, it: *Iter, allocator: ?std.mem.Allocator) Error!bool {
-        const c = (it.viewMust() catch unreachable).as_posArg().PosArg;
+        const c = (it.viewMust() catch unreachable).as_posArg().posArg;
         if (std.mem.eql(u8, self.name, c)) {
             _ = it.next() catch unreachable;
             _ = it.reinit(it.config);

--- a/src/command.zig
+++ b/src/command.zig
@@ -799,7 +799,7 @@ pub const Command = struct {
                     return Error.UnknownOpt;
                 },
                 .posArg, .arg => {
-                    it.flag_termiantor = true;
+                    it.fsm_to_pos();
                     break;
                 },
                 else => unreachable,
@@ -851,7 +851,7 @@ pub const Command = struct {
         const c = (it.viewMust() catch unreachable).as_posArg().posArg;
         if (std.mem.eql(u8, self.name, c)) {
             _ = it.next() catch unreachable;
-            _ = it.reinit(it.config);
+            it.reinit();
             @field(r, s) = @unionInit(@TypeOf(@field(r, s)), self.name, try self.parseAlloc(it, allocator));
             return true;
         }
@@ -997,19 +997,6 @@ pub const Command = struct {
 
     test "parse, Error TokenIter" {
         const cmd: Self = .{ .name = "exp" };
-        {
-            comptime var c = cmd;
-            var it = try Iter.initLine("--help=", null, .{});
-            defer it.deinit();
-            try testing.expectError(Error.TokenIter, c.parse(&it));
-        }
-        {
-            comptime var c = cmd;
-            _ = c.posArg("number", u32, .{ .default = 1 });
-            var it = try Iter.initLine("-a=", null, .{});
-            defer it.deinit();
-            try testing.expectError(Error.TokenIter, c.parse(&it));
-        }
         {
             comptime var c = cmd;
             var it = try Iter.initLine("--", null, .{ .terminator = "==" });

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -170,8 +170,7 @@ pub const OptArg = struct {
                     return Error.Missing;
                 };
                 s = switch (t) {
-                    .optArg => |o| o.arg,
-                    .arg => |a| a,
+                    .optArg, .arg => |a| a,
                     else => {
                         if (self.meta.log) |log| {
                             log("{s}: Expect {s} but {}", .{ opt, self.arg_name, t });

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -36,11 +36,11 @@ pub const Meta = struct {
 };
 
 pub fn hitOpt(self: anytype, opt: token.Type) bool {
-    switch (opt.Opt) {
-        .Short => |s| {
+    switch (opt.opt) {
+        .short => |s| {
             if (s == self.short) return true;
         },
-        .Long => |l| {
+        .long => |l| {
             if (self.long) |long|
                 if (std.mem.eql(u8, long, l)) return true;
         },
@@ -148,13 +148,13 @@ pub const OptArg = struct {
                         }
                         return Error.Missing;
                     };
-                    if (t != .Arg) {
+                    if (t != .arg) {
                         if (self.meta.log) |log| {
                             log("{s}: Expect {s}[{d}] but {}", .{ opt, self.arg_name, i, t });
                         }
                         return Error.Missing;
                     }
-                    s = t.Arg;
+                    s = t.arg;
                     item.* = self.meta.parseAny(s) orelse {
                         if (self.meta.log) |log| {
                             log("{s}: Parse {s}[{d}] but fail from {s}", .{ opt, self.arg_name, i, s });
@@ -170,8 +170,8 @@ pub const OptArg = struct {
                     return Error.Missing;
                 };
                 s = switch (t) {
-                    .OptArg => |o| o.arg,
-                    .Arg => |a| a,
+                    .optArg => |o| o.arg,
+                    .arg => |a| a,
                     else => {
                         if (self.meta.log) |log| {
                             log("{s}: Expect {s} but {}", .{ opt, self.arg_name, t });
@@ -235,7 +235,7 @@ pub const PosArg = struct {
                     }
                     return Error.Missing;
                 };
-                s = t.as_posArg().PosArg;
+                s = t.as_posArg().posArg;
                 item.* = self.meta.parseAny(s) orelse {
                     if (self.meta.log) |log| {
                         log("Parse {s}[{d}] but fail from {s}", .{ self.arg_name, i, s });
@@ -250,7 +250,7 @@ pub const PosArg = struct {
                 }
                 return Error.Missing;
             };
-            s = t.as_posArg().PosArg;
+            s = t.as_posArg().posArg;
             var value = self.meta.parseAny(s) orelse {
                 if (self.meta.log) |log| {
                     log("Parse {s} but fail from {s}", .{ self.arg_name, s });


### PR DESCRIPTION
- updates the fields of all tagged union to follow [naming conventions](https://ziglang.org/documentation/0.14.0/#Names)
- [token] simplify `Type.optArg` to `[]const u8`
- optimize many runtime log and compile error log
- [token] use `String` alias instead of `[]const u8` (it's too long...)
- [token] use FSM to iterate multiple-shorts, short with argument, long with argument, tokens and so on
- [token] implement powerful IterWrapper to support cached view&next
- [token] implement ListIter to support BaseIter.list and some other test case
- [token] **_fix nextAllBase losing the first remaining token_**