### PR TITLE
Feature: support to set callBackFn for the Command

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) void {
     const ex_dirname = "examples";
     const examples_step = b.step("examples", "Build examples");
 
-    if (std.fs.cwd().openDir(ex_dirname, .{ .iterate = true })) |d| {
+    if ((std.fs.openDirAbsolute(b.build_root.path.?, .{}) catch unreachable).openDir(ex_dirname, .{ .iterate = true })) |d| {
         var it = d.iterate();
         const ex_prefix = "ex-";
         const ex_suffix = ".zig";

--- a/examples/ex-03.cmd-callback.zig
+++ b/examples/ex-03.cmd-callback.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const zargs = @import("zargs");
+const Command = zargs.Command;
+const TokenIter = zargs.TokenIter;
+
+pub fn main() !void {
+    comptime var install: Command = .{ .name = "install" };
+    _ = install.posArg("name", []const u8, .{}).optArg("count", u32, .{ .short = 'c', .default = 1 });
+    comptime install.callBack(struct {
+        const C = install;
+        fn f(r: *C.Result()) void {
+            r.count *= 2;
+            std.debug.print("[{s}] Installing {s} (count:{d})\n", .{ C.name, r.name, r.count });
+        }
+    }.f);
+
+    comptime var remove: Command = .{ .name = "remove" };
+    _ = remove.posArg("name", []const u8, .{}).optArg("count", u32, .{ .short = 'c', .default = 1 });
+    comptime remove.callBack(struct {
+        const C = remove;
+        fn f(r: *C.Result()) void {
+            r.count *= 10;
+            std.debug.print("[{s}] Removing {s} (count:{d})\n", .{ C.name, r.name, r.count });
+        }
+    }.f);
+
+    comptime var cmd: Command = .{ .name = "demo", .use_subCmd = "action", .description = "This is a simple demo" };
+    _ = cmd.opt("verbose", u32, .{ .short = 'v' });
+    _ = cmd.subCmd(install).subCmd(remove);
+    comptime cmd.callBack(struct {
+        const C = cmd;
+        fn f(r: *C.Result()) void {
+            std.debug.print("[{s}] Success to do {s}\n", .{ C.name, @tagName(r.action) });
+        }
+    }.f);
+
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+    var it = try TokenIter.init(allocator, .{});
+    defer it.deinit();
+    _ = try it.next();
+
+    _ = cmd.parse(&it) catch |err| {
+        std.debug.print("Fail to parse because of {any}\n", .{err});
+        std.debug.print("\n{s}\n", .{cmd.usage()});
+        std.process.exit(1);
+    };
+}


### PR DESCRIPTION
- the `callBackFn` of the Command would be called when the parser completes.
- new example `ex-03.cmd-callback.zig` which demonstrates how to use this new feature.
- bugfix about finding examples directory