### PR TITLE
Misc: [build] `.zig.zon` 里的 `.version` 要及时更新

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zargs,
     .fingerprint = 0x421ffecd6ed6acb6,
-    .version = "0.14.4",
+    .version = "0.14.6",
     .minimum_zig_version = "0.14.0",
 
     .paths = .{


### PR DESCRIPTION
这个字段会体现在 `.dependencies` 下包的 `.hash` 里（下载到本地的包，会存放在以 `.hash` 命名的目录中）