### PR TITLE
Build: Upgrade to Zig 0.15.1

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,9 +45,9 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2.0.5
         with:
-          version: 0.14.0
+          version: 0.15.1
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,9 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2.0.5
         with:
-          version: 0.14.0
+          version: 0.15.1
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pub fn main() !void {
     var args = cmd.config(.{ .style = .classic }).parse(allocator) catch |e|
         zargs.exitf(e, 1, "\n{s}\n", .{cmd.usageString()});
     defer cmd.destroy(&args, allocator);
-    if (args.logfile) |logfile| std.debug.print("Store log into {}\n", .{logfile});
+    if (args.logfile) |logfile| std.debug.print("Store log into {f}\n", .{logfile});
     switch (args.action) {
         .install => |a| {
             std.debug.print("Installing {s}\n", .{a.name});
@@ -107,9 +107,11 @@ In your `build.zig`, use `addImport` (for example):
 ```zig
 const exe = b.addExecutable(.{
     .name = "your_app",
-    .root_source_file = b.path("src/main.zig"),
-    .target = b.standardTargetOptions(.{}),
-    .optimize = b.standardOptimizeOption(.{}),
+    .root_module = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = b.standardTargetOptions(.{}),
+        .optimize = b.standardOptimizeOption(.{}),
+    }),
 });
 exe.root_module.addImport("zargs", b.dependency("zargs", .{}).module("zargs"));
 b.installArtifact(exe);

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,7 +54,7 @@ pub fn main() !void {
     var args = cmd.config(.{ .style = .classic }).parse(allocator) catch |e|
         zargs.exitf(e, 1, "\n{s}\n", .{cmd.usageString()});
     defer cmd.destroy(&args, allocator);
-    if (args.logfile) |logfile| std.debug.print("Store log into {}\n", .{logfile});
+    if (args.logfile) |logfile| std.debug.print("Store log into {f}\n", .{logfile});
     switch (args.action) {
         .install => |a| {
             std.debug.print("Installing {s}\n", .{a.name});
@@ -107,9 +107,11 @@ zig fetch --save https://github.com/kioz-wang/zargs/archive/refs/tags/v0.14.3.ta
 ```zig
 const exe = b.addExecutable(.{
     .name = "your_app",
-    .root_source_file = b.path("src/main.zig"),
-    .target = b.standardTargetOptions(.{}),
-    .optimize = b.standardOptimizeOption(.{}),
+    .root_module = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = b.standardTargetOptions(.{}),
+        .optimize = b.standardOptimizeOption(.{}),
+    }),
 });
 exe.root_module.addImport("zargs", b.dependency("zargs", .{}).module("zargs"));
 b.installArtifact(exe);

--- a/build.zig
+++ b/build.zig
@@ -79,9 +79,11 @@ pub fn build(b: *std.Build) void {
             exe_name = exe_name[0..(exe_name.len - ex_suffix.len)];
             const ex_exe = b.addExecutable(.{
                 .name = exe_name,
-                .root_source_file = b.path(ex_dirname).path(b, e.name),
-                .target = target,
-                .optimize = optimize,
+                .root_module = b.createModule(.{
+                    .root_source_file = b.path(ex_dirname).path(b, e.name),
+                    .target = target,
+                    .optimize = optimize,
+                }),
             });
             ex_exe.root_module.addImport("zargs", mod_zargs);
             ex_exe.root_module.addImport("par", mod_par);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.14.8",
     .dependencies = .{
         .zterm = .{
-            .url = "git+https://github.com/npc1054657282/zterm#53d24a00ac00c17dd953c8540416dab42e095b95",
-            .hash = "zterm-0.14.4-buNfZ_NCBADrIaWav2TsxdQE97hJQQG7QnW6mi67ItlE",
+            .url = "https://github.com/kioz-wang/zterm/archive/refs/tags/v0.15.0-alpha.0.tar.gz",
+            .hash = "zterm-0.15.0-buNfZ_NCBABoC84oWTAg5slE62NYqgrOg7822amyYVmv",
         },
     },
     .minimum_zig_version = "0.15.1",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,11 +4,11 @@
     .version = "0.14.8",
     .dependencies = .{
         .zterm = .{
-            .url = "git+https://github.com/kioz-wang/zterm#5a47f9a17285125fe35cb878759e01647899d814",
-            .hash = "zterm-0.14.4-buNfZ2o2BABFTy1TcC-Ecc2dytTdrX-fa1m98pioOQn-",
+            .url = "git+https://github.com/npc1054657282/zterm#53d24a00ac00c17dd953c8540416dab42e095b95",
+            .hash = "zterm-0.14.4-buNfZ_NCBADrIaWav2TsxdQE97hJQQG7QnW6mi67ItlE",
         },
     },
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
 
     .paths = .{
         "build.zig",

--- a/examples/ex-02.simple.zig
+++ b/examples/ex-02.simple.zig
@@ -39,7 +39,7 @@ pub fn main() !void {
     var args = cmd.config(.{ .style = .classic }).parse(allocator) catch |e|
         zargs.exitf(e, 1, "\n{s}\n", .{cmd.usageString()});
     defer cmd.destroy(&args, allocator);
-    if (args.logfile) |logfile| std.debug.print("Store log into {}\n", .{logfile});
+    if (args.logfile) |logfile| std.debug.print("Store log into {f}\n", .{logfile});
     switch (args.action) {
         .install => |a| {
             std.debug.print("Installing {s}\n", .{a.name});

--- a/examples/ex-03.cmd-callback.zig
+++ b/examples/ex-03.cmd-callback.zig
@@ -19,7 +19,7 @@ pub fn main() !void {
             install.callBack(struct {
                 fn f(r: *install.Result()) void {
                     r.count *= 2;
-                    std.debug.print("[{s}] Installing {s} (count:{d})\n", .{ install.name, r.name, r.count });
+                    std.debug.print("[{any}] Installing {s} (count:{d})\n", .{ install.name, r.name, r.count });
                 }
             }.f),
         )
@@ -27,14 +27,14 @@ pub fn main() !void {
             remove.callBack(struct {
                 fn f(r: *remove.Result()) void {
                     r.count *= 10;
-                    std.debug.print("[{s}] Removing {s} (count:{d})\n", .{ remove.name, r.name, r.count });
+                    std.debug.print("[{any}] Removing {s} (count:{d})\n", .{ remove.name, r.name, r.count });
                 }
             }.f),
         )
         .arg(Arg.opt("verbose", u32).short('v'));
     const cmd = _cmd.callBack(struct {
         fn f(r: *_cmd.Result()) void {
-            std.debug.print("[{s}] Success to do {s}\n", .{ _cmd.name, @tagName(r.action) });
+            std.debug.print("[{any}] Success to do {s}\n", .{ _cmd.name, @tagName(r.action) });
         }
     }.f);
 

--- a/examples/ex-06.copy.zig
+++ b/examples/ex-06.copy.zig
@@ -29,9 +29,11 @@ pub fn main() !void {
     if (args.verbose) {
         std.debug.print("Try copy {s} to {s} with max 0x{x} bytes\n", .{ args.source.s, args.target.s, args.max });
     }
-    // const content = try args.source.v.reader().any().readAllAlloc(allocator, args.max);
+    // var reader = args.source.v.reader(&@as([0]u8, .{}));
+    // const content = try reader.interface.readAlloc(allocator, args.max);
     // defer allocator.free(content);
-    try args.target.v.writer().any().writeAll(args.source.v);
+    var writer = args.target.v.writer(&@as([0]u8, .{}));
+    try writer.interface.writeAll(args.source.v);
     if (args.verbose) {
         std.debug.print("Done with 0x{x} bytes\n", .{args.source.v.len});
     }

--- a/examples/ex-mess.zig
+++ b/examples/ex-mess.zig
@@ -104,14 +104,14 @@ pub fn main() !void {
         zargs.exitf(e, 1, "\n{s}\n", .{cmd.usageString()});
     defer cmd.destroy(&args, allocator);
     // it.debug(false);
-    std.debug.print("{}\n\n", .{args});
+    std.debug.print("{any}\n\n", .{args});
 
     switch (args.sub) {
         .sub0 => |a| {
-            std.debug.print("Capture subCmd sub0\n{}\n", .{a});
+            std.debug.print("Capture subCmd sub0\n{any}\n", .{a});
         },
         .sub1 => |a| {
-            std.debug.print("Capture subCmd sub1\n{}\n", .{a});
+            std.debug.print("Capture subCmd sub1\n{any}\n", .{a});
         },
     }
 
@@ -119,6 +119,6 @@ pub fn main() !void {
         std.debug.print("\nRemain command line input:\n\t", .{});
         const remain = try it.nextAllBase(allocator);
         defer allocator.free(remain);
-        std.debug.print("{s}\n", .{remain});
+        std.debug.print("{any}\n", .{remain});
     }
 }

--- a/src/command/AFormatter.zig
+++ b/src/command/AFormatter.zig
@@ -24,9 +24,9 @@ pub fn init(arg: Arg, config: Config) Self {
     self.left_length = blk: {
         var pure = self;
         pure.config.style = .none;
-        var counting = std.io.countingWriter(std.io.null_writer);
-        try pure.usage1(counting.writer());
-        break :blk counting.bytes_written;
+        var counting = std.Io.Writer.Discarding.init(&@as([0]u8, .{}));
+        try pure.usage1(&counting.writer);
+        break :blk counting.fullCount();
     };
     return self;
 }
@@ -37,13 +37,13 @@ pub fn usage(self: Self, w: anytype) !void {
     var is_first = true;
 
     if (meta.default != null or meta.rawDefault != null or ztype.checker.isSlice(self.arg.T)) {
-        try w.print("{}", .{sRec.apply(sConfig.usage.optional)});
+        try w.print("{f}", .{sRec.apply(sConfig.usage.optional)});
         if (!ztype.checker.isSlice(self.arg.T)) {
             try w.writeByte('[');
         }
     }
     if ((meta.short.len > 0 or meta.long.len > 0) and meta.argName != null) {
-        try w.print("{}", .{sRec.apply(sConfig.usage.optarg)});
+        try w.print("{f}", .{sRec.apply(sConfig.usage.optarg)});
     }
     if (meta.short.len > 0) {
         try w.writeAll(self.config.token.prefix.short);
@@ -58,7 +58,7 @@ pub fn usage(self: Self, w: anytype) !void {
     }
     if (meta.argName) |s| {
         if (!is_first) try w.writeByte(' ');
-        try w.print("{}", .{sRec.apply(sConfig.usage.argument)});
+        try w.print("{f}", .{sRec.apply(sConfig.usage.argument)});
         if (!is_first or (meta.default == null and meta.rawDefault == null)) {
             try w.writeByte('{');
         }
@@ -73,12 +73,12 @@ pub fn usage(self: Self, w: anytype) !void {
         }
     }
     if (meta.default != null or meta.rawDefault != null or ztype.checker.isSlice(self.arg.T)) {
-        try w.print("{}", .{sRec.restore(sConfig.usage.optional)});
+        try w.print("{f}", .{sRec.restore(sConfig.usage.optional)});
         if (!ztype.checker.isSlice(self.arg.T)) {
             try w.writeByte(']');
         }
     }
-    try w.print("{}", .{sRec.reset()});
+    try w.print("{f}", .{sRec.reset()});
     if (self.arg.class == .opt and self.arg.T != bool or self.arg.class == .optArg and ztype.checker.isSlice(self.arg.T)) {
         try w.writeAll("...");
     }
@@ -91,21 +91,21 @@ fn usage1(self: Self, w: anytype) !void {
 
     for (meta.short, 0..) |short, i| {
         if (i != 0) {
-            try w.print("{}", .{sRec.apply(sConfig.usage.alias)});
+            try w.print("{f}", .{sRec.apply(sConfig.usage.alias)});
         }
         if (is_first) is_first = false else try w.writeAll(", ");
         try w.writeAll(tConfig.prefix.short);
         try w.writeByte(short);
-        try w.print("{}", .{sRec.reset()});
+        try w.print("{f}", .{sRec.reset()});
     }
     for (meta.long, 0..) |long, i| {
         if (i != 0) {
-            try w.print("{}", .{sRec.apply(sConfig.usage.alias)});
+            try w.print("{f}", .{sRec.apply(sConfig.usage.alias)});
         }
         if (is_first) is_first = false else try w.writeAll(", ");
         try w.writeAll(tConfig.prefix.long);
         try w.writeAll(long);
-        try w.print("{}", .{sRec.reset()});
+        try w.print("{f}", .{sRec.reset()});
     }
     if (meta.argName) |s| {
         if (!is_first) try w.writeByte(' ');
@@ -150,7 +150,7 @@ pub fn help(self: Self, w: anytype) !void {
         }
         if (meta.default != null or meta.rawDefault != null) {
             if (meta.help != null) try w.writeByte(' ');
-            try w.print("{}({s} is {}{}{}){}", .{
+            try w.print("{f}({s} is {f}{f}{f}){f}", .{
                 sRec.apply(sConfig.help.default),
                 if (meta.default != null) "default" else "default input",
                 sRec.apply(sConfig.help.defaultValue),
@@ -163,23 +163,23 @@ pub fn help(self: Self, w: anytype) !void {
 
     if (meta.ranges != null or meta.choices != null) {
         try self.indent(w, &is_firstline);
-        try w.print("{}possible: {}", .{
+        try w.print("{f}possible: {f}", .{
             sRec.apply(sConfig.help.possible),
             sRec.apply(sConfig.help.possibleValue),
         });
         if (meta.ranges) |_| {
-            try w.print("{}", .{any(self.arg.getRanges().?.rs, .{ .multiple = .dump(" or ", 1) })});
+            try w.print("{f}", .{any(self.arg.getRanges().?.rs, .{ .multiple = .dump(" or ", 1) })});
         }
         if (meta.choices) |_| {
             if (meta.ranges != null) try w.writeAll(" or ");
-            try w.print("{}", .{any(self.arg.getChoices().?.*, .{})});
+            try w.print("{f}", .{any(self.arg.getChoices().?.*, .{})});
         }
-        try w.print("{}", .{sRec.reset()});
+        try w.print("{f}", .{sRec.reset()});
     }
 
     if (meta.rawChoices) |cs| {
         try self.indent(w, &is_firstline);
-        try w.print("{}possible inputs: {}{}{}", .{
+        try w.print("{f}possible inputs: {f}{f}{f}", .{
             sRec.apply(sConfig.help.possible),
             sRec.apply(sConfig.help.possibleInput),
             any(cs, .{}),
@@ -190,7 +190,7 @@ pub fn help(self: Self, w: anytype) !void {
     if (meta.ranges == null and meta.choices == null and meta.rawChoices == null) {
         if (@typeInfo(Base(self.arg.T)) == .@"enum" and self.arg.getParseFn() == null and !std.meta.hasMethod(Base(self.arg.T), "parse")) {
             try self.indent(w, &is_firstline);
-            try w.print("{}Enum: {}{}{}", .{
+            try w.print("{f}Enum: {f}{f}{f}", .{
                 sRec.apply(sConfig.help.enum_),
                 sRec.apply(sConfig.help.enumValue),
                 any(std.meta.fieldNames(Base(self.arg.T)).*, .{}),

--- a/src/command/Argument.zig
+++ b/src/command/Argument.zig
@@ -53,12 +53,12 @@ const Meta = struct {
 const Class = enum { opt, optArg, posArg };
 
 // TODO remove this ?
-pub fn format(self: Self, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
     try writer.writeAll(comptimePrint("{s}({s},{s})", .{ @tagName(self.class), self.name, @typeName(self.T) }));
 }
 fn log(self: Self, comptime fmt: []const u8, args: anytype) void {
     // TODO maybe compileErrorf()?
-    std.debug.print("{} ", .{self});
+    std.debug.print("{f} ", .{self});
     std.debug.print(fmt, args);
     std.debug.print("\n", .{});
 }
@@ -67,7 +67,7 @@ pub fn opt(name: LiteralString, T: type) Self {
     const arg: Self = .{ .name = name, .T = T, .class = .opt };
     // Check T
     if (T != bool and @typeInfo(T) != .int) {
-        @compileError(comptimePrint("{} expect .bool or .int type, found '{s}'", .{ arg, @typeName(T) }));
+        @compileError(comptimePrint("{f} expect .bool or .int type, found '{s}'", .{ arg, @typeName(T) }));
     }
     // Initialize Arg
     return arg;
@@ -84,7 +84,7 @@ pub fn posArg(name: LiteralString, T: type) Self {
     // Check T
     _ = Base(T);
     if (isSlice(T)) {
-        @compileError(comptimePrint("{} illegal type, consider to use .nextAllBase of TokenIter", .{arg}));
+        @compileError(comptimePrint("{f} illegal type, consider to use .nextAllBase of TokenIter", .{arg}));
     }
     // Initialize Arg
     return arg;
@@ -96,10 +96,10 @@ pub fn help(self: Self, s: LiteralString) Self {
 }
 pub fn default(self: Self, v: self.T) Self {
     if (isOptional(self.T)) {
-        @compileError(comptimePrint("{} not support .default, it's forced to be null", .{self}));
+        @compileError(comptimePrint("{f} not support .default, it's forced to be null", .{self}));
     }
     if (isSlice(self.T)) {
-        @compileError(comptimePrint("{} not support .default, it's forced to be empty slice", .{self}));
+        @compileError(comptimePrint("{f} not support .default, it's forced to be empty slice", .{self}));
     }
     var arg = self;
     arg.meta.default = @ptrCast(&v);
@@ -107,7 +107,7 @@ pub fn default(self: Self, v: self.T) Self {
 }
 pub fn parseFn(self: Self, f: par.Fn(self.T)) Self {
     if (self.class == .opt) {
-        @compileError(comptimePrint("{} not support .parseFn", .{self}));
+        @compileError(comptimePrint("{f} not support .parseFn", .{self}));
     }
     var arg = self;
     arg.meta.parseFn = @ptrCast(&f);
@@ -120,7 +120,7 @@ pub fn callbackFn(self: Self, f: fn (*TryOptional(self.T)) void) Self {
 }
 pub fn short(self: Self, c: u8) Self {
     if (self.class == .posArg) {
-        @compileError(comptimePrint("{} not support .short", .{self}));
+        @compileError(comptimePrint("{f} not support .short", .{self}));
     }
     var arg = self;
     arg.meta.short = arg.meta.short ++ .{c};
@@ -128,7 +128,7 @@ pub fn short(self: Self, c: u8) Self {
 }
 pub fn long(self: Self, s: String) Self {
     if (self.class == .posArg) {
-        @compileError(comptimePrint("{} not support .long", .{self}));
+        @compileError(comptimePrint("{f} not support .long", .{self}));
     }
     var arg = self;
     arg.meta.long = arg.meta.long ++ .{s};
@@ -136,7 +136,7 @@ pub fn long(self: Self, s: String) Self {
 }
 pub fn argName(self: Self, s: LiteralString) Self {
     if (self.class == .opt) {
-        @compileError(comptimePrint("{} not support .argName", .{self}));
+        @compileError(comptimePrint("{f} not support .argName", .{self}));
     }
     var arg = self;
     arg.meta.argName = s;
@@ -144,10 +144,10 @@ pub fn argName(self: Self, s: LiteralString) Self {
 }
 pub fn ranges(self: Self, rs: Ranges(Base(self.T))) Self {
     if (self.class == .opt) {
-        @compileError(comptimePrint("{} not support .ranges", .{self}));
+        @compileError(comptimePrint("{f} not support .ranges", .{self}));
     }
     if (self.meta.rawChoices) |_| {
-        @compileError(comptimePrint("{} .ranges conflicts with .rawChoices", .{self}));
+        @compileError(comptimePrint("{f} .ranges conflicts with .rawChoices", .{self}));
     }
     var arg = self;
     arg.meta.ranges = @ptrCast(&rs._checkOut());
@@ -155,10 +155,10 @@ pub fn ranges(self: Self, rs: Ranges(Base(self.T))) Self {
 }
 pub fn choices(self: Self, cs: []const Base(self.T)) Self {
     if (self.class == .opt) {
-        @compileError(comptimePrint("{} not support .choices", .{self}));
+        @compileError(comptimePrint("{f} not support .choices", .{self}));
     }
     if (self.meta.rawChoices) |_| {
-        @compileError(comptimePrint("{} .choices conflicts with .rawChoices", .{self}));
+        @compileError(comptimePrint("{f} .choices conflicts with .rawChoices", .{self}));
     }
     if (cs.len == 0) {
         @compileError(comptimePrint("requires at least one choice", .{}));
@@ -169,10 +169,10 @@ pub fn choices(self: Self, cs: []const Base(self.T)) Self {
 }
 pub fn rawChoices(self: Self, cs: []const String) Self {
     if (self.class == .opt) {
-        @compileError(comptimePrint("{} not support .rawChoices", .{self}));
+        @compileError(comptimePrint("{f} not support .rawChoices", .{self}));
     }
     if (self.meta.ranges != null or self.meta.choices != null) {
-        @compileError(comptimePrint("{} .rawChoices conflicts with .ranges or .choices", .{self}));
+        @compileError(comptimePrint("{f} .rawChoices conflicts with .ranges or .choices", .{self}));
     }
     if (cs.len == 0) {
         @compileError(comptimePrint("requires at least one raw_choice", .{}));
@@ -183,13 +183,13 @@ pub fn rawChoices(self: Self, cs: []const String) Self {
 }
 pub fn rawDefault(self: Self, s: String) Self {
     if (isOptional(self.T)) {
-        @compileError(comptimePrint("{} not support .rawDefault, it's forced to be null", .{self}));
+        @compileError(comptimePrint("{f} not support .rawDefault, it's forced to be null", .{self}));
     }
     if (isSlice(self.T)) {
-        @compileError(comptimePrint("{} not support .rawDefault, it's forced to be empty slice", .{self}));
+        @compileError(comptimePrint("{f} not support .rawDefault, it's forced to be empty slice", .{self}));
     }
     if (isArray(self.T)) {
-        @compileError(comptimePrint("{} not support .rawDefault", .{self}));
+        @compileError(comptimePrint("{f} not support .rawDefault", .{self}));
     }
     var arg = self;
     arg.meta.rawDefault = s;
@@ -219,13 +219,13 @@ pub fn _checkOut(self: Self) Self {
             }
         }
         if (self.meta.default != null and self.meta.rawDefault != null) {
-            @compileError(comptimePrint("{} .rawDefault conflicts with .default", .{self}));
+            @compileError(comptimePrint("{f} .rawDefault conflicts with .default", .{self}));
         }
     }
     if (self.class == .opt or self.class == .optArg) {
         // Check short and long
         if (self.meta.short.len == 0 and self.meta.long.len == 0) {
-            @compileError(comptimePrint("{} requires short or long", .{self}));
+            @compileError(comptimePrint("{f} requires short or long", .{self}));
         }
     }
     if (self.class == .optArg or self.class == .posArg) {
@@ -236,7 +236,7 @@ pub fn _checkOut(self: Self) Self {
     }
     if (self.meta.rawDefault) |s| {
         if (!self.checkInput(s)) {
-            @compileError(comptimePrint("{} invalid default input: {s}", .{ self, s }));
+            @compileError(comptimePrint("{f} invalid default input: {s}", .{ self, s }));
         }
     }
     return arg;
@@ -274,12 +274,12 @@ fn checkValue(self: Self, value: Base(self.T)) bool {
         if (comptime self.meta.ranges) |_| {
             const rs_found = self.getRanges().?.contain(value);
             if (!cs_found and !rs_found) {
-                self.log("parsed as {} but out of choices{} and ranges{}", .{ any(value, .{}), any(cs.*, .{}), any(self.getRanges().?.rs, .{}) });
+                self.log("parsed as {f} but out of choices{f} and ranges{f}", .{ any(value, .{}), any(cs.*, .{}), any(self.getRanges().?.rs, .{}) });
             }
             return cs_found or rs_found;
         } else {
             if (!cs_found) {
-                self.log("parsed as {} but out of choices{}", .{ any(value, .{}), any(cs.*, .{}) });
+                self.log("parsed as {f} but out of choices{f}", .{ any(value, .{}), any(cs.*, .{}) });
             }
             return cs_found;
         }
@@ -287,7 +287,7 @@ fn checkValue(self: Self, value: Base(self.T)) bool {
         if (comptime self.meta.ranges) |_| {
             const rs_found = self.getRanges().?.contain(value);
             if (!rs_found) {
-                self.log("parsed as {} but out of ranges{}", .{ any(value, .{}), any(self.getRanges().?.rs, .{}) });
+                self.log("parsed as {f} but out of ranges{f}", .{ any(value, .{}), any(self.getRanges().?.rs, .{}) });
             }
             return rs_found;
         } else {
@@ -303,7 +303,7 @@ fn getCallbackFn(self: Self) ?*const fn (*TryOptional(self.T)) void {
 }
 pub fn parseValue(self: Self, s: String, a_maybe: ?Allocator) ?Base(self.T) {
     if (!self.checkInput(s)) {
-        self.log("to parse {s} but out of rawChoices{}", .{ s, any(self.meta.rawChoices, .{}) });
+        self.log("to parse {s} but out of rawChoices{f}", .{ s, any(self.meta.rawChoices, .{}) });
         return null;
     }
     if (if (comptime self.getParseFn()) |f| f(s, a_maybe) else par.any(Base(self.T), s, a_maybe)) |value| {
@@ -360,11 +360,11 @@ fn consumeOptArg(self: Self, r: anytype, it: *token.Iter, a_maybe: ?Allocator) E
         if (comptime isArray(self.T)) {
             for (&@field(r, self.name), 0..) |*item, i| {
                 const t = it.nextMust() catch |err| {
-                    self.log("requires {s}[{d}] after {s} but {any}", .{ self.meta.argName.?, i, prefix, err });
+                    self.log("requires {s}[{d}] after {f} but {any}", .{ self.meta.argName.?, i, prefix, err });
                     return Error.Missing;
                 };
                 if (t != .arg) {
-                    self.log("requires {s}[{d}] after {s} but {}", .{ self.meta.argName.?, i, prefix, t });
+                    self.log("requires {s}[{d}] after {f} but {f}", .{ self.meta.argName.?, i, prefix, t });
                     return Error.Missing;
                 }
                 s = t.arg;
@@ -372,13 +372,13 @@ fn consumeOptArg(self: Self, r: anytype, it: *token.Iter, a_maybe: ?Allocator) E
             }
         } else {
             const t = it.nextMust() catch |err| {
-                self.log("requires {s} after {s} but {any}", .{ self.meta.argName.?, prefix, err });
+                self.log("requires {s} after {f} but {any}", .{ self.meta.argName.?, prefix, err });
                 return Error.Missing;
             };
             s = switch (t) {
                 .optArg, .arg => |arg| arg,
                 else => {
-                    self.log("requires {s} after {s} but {}", .{ self.meta.argName.?, prefix, t });
+                    self.log("requires {s} after {f} but {f}", .{ self.meta.argName.?, prefix, t });
                     return Error.Missing;
                 },
             };
@@ -392,7 +392,7 @@ fn consumeOptArg(self: Self, r: anytype, it: *token.Iter, a_maybe: ?Allocator) E
                 list.appendSliceAssumeCapacity(@field(r, self.name));
                 list.appendAssumeCapacity(value);
                 a_maybe.?.free(@field(r, self.name));
-                break :blk list.toOwnedSlice() catch return Error.Allocator;
+                break :blk list.toOwnedSlice(a_maybe.?) catch return Error.Allocator;
             } else value;
         }
         return true;

--- a/src/command/Argument.zig
+++ b/src/command/Argument.zig
@@ -645,7 +645,7 @@ test "Consume posArg" {
 }
 test "Consume posArg with ranges or rawChoices" {
     const Mem = struct {
-        buf: []u8 = undefined,
+        buf: []u8 = &@as([0]u8, .{}),
         len: usize,
         pub fn parse(s: String, a: ?Allocator) ?@This() {
             const allocator = a orelse return null;

--- a/src/command/CFormatter.zig
+++ b/src/command/CFormatter.zig
@@ -21,9 +21,9 @@ pub fn init(c: Command) Self {
     self.left_length = blk: {
         var pure = self;
         pure.c._config.style = .none;
-        var counting = std.io.countingWriter(std.io.null_writer);
-        try pure.usage1(counting.writer());
-        break :blk counting.bytes_written;
+        var counting = std.Io.Writer.Discarding.init(&@as([0]u8, .{}));
+        try pure.usage1(&counting.writer);
+        break :blk counting.fullCount();
     };
     return self;
 }
@@ -49,7 +49,7 @@ pub fn usage(self: Self, w: anytype) !void {
         try AFormatter.init(m, config).usage(w);
     }
     if (self.c._stat.posArg != 0 or self.c._stat.cmd != 0) {
-        try w.print(" {}[{s}]{}", .{
+        try w.print(" {f}[{s}]{f}", .{
             sRec.apply(sConfig.usage.optional),
             tConfig.terminator,
             sRec.reset(),
@@ -86,7 +86,7 @@ pub fn usage1(self: Self, w: anytype) !void {
     var sRec = Config.StyleRecord(3){};
     try w.writeAll(self.c.name[0]);
     if (self.c.name.len > 1) {
-        try w.print("{}{}{}", .{
+        try w.print("{f}{f}{f}", .{
             sRec.apply(sConfig.usage.alias),
             any(@as([]const LiteralString, self.c.name[1..]), .{ .multiple = .{ .begin = ", ", .separator = ", ", .end = "" } }),
             sRec.reset(),
@@ -119,7 +119,7 @@ pub fn help(self: Self, w: anytype) !void {
     _, const fConfig, const sConfig = config.destruct();
     var sRec = Config.StyleRecord(5){};
 
-    try w.print("{}Usage:{}\n{s}", .{
+    try w.print("{f}Usage:{f}\n{s}", .{
         sRec.apply(sConfig.title),
         sRec.reset(),
         " " ** fConfig.indent,
@@ -135,7 +135,7 @@ pub fn help(self: Self, w: anytype) !void {
         try w.writeByte('\n');
         var is_first = true;
         if (self.c.meta.version) |s| {
-            try w.print("{}Version{} {s}", .{
+            try w.print("{f}Version{f} {s}", .{
                 sRec.apply(sConfig.title),
                 sRec.reset(),
                 s,
@@ -144,7 +144,7 @@ pub fn help(self: Self, w: anytype) !void {
         }
         if (self.c.meta.author) |s| {
             if (!is_first) try w.writeByte('\t');
-            try w.print("{}Author{} <{s}>", .{
+            try w.print("{f}Author{f} <{s}>", .{
                 sRec.apply(sConfig.title),
                 sRec.reset(),
                 s,
@@ -153,7 +153,7 @@ pub fn help(self: Self, w: anytype) !void {
         }
         if (self.c.meta.homepage) |s| {
             if (!is_first) try w.writeByte('\t');
-            try w.print("{}Homepage{} {}{s}{}", .{
+            try w.print("{f}Homepage{f} {f}{s}{f}", .{
                 sRec.apply(sConfig.title),
                 sRec.reset(),
                 sRec.apply(sConfig.homepage),
@@ -165,7 +165,7 @@ pub fn help(self: Self, w: anytype) !void {
     }
 
     if (self.c._stat.opt != 0 or self.c._builtin_help != null) {
-        try w.print("\n{}Option:{}\n", .{
+        try w.print("\n{f}Option:{f}\n", .{
             sRec.apply(sConfig.title),
             sRec.reset(),
         });
@@ -179,7 +179,7 @@ pub fn help(self: Self, w: anytype) !void {
     }
 
     if (self.c._stat.optArg != 0) {
-        try w.print("\n{}Option with arguments:{}\n", .{
+        try w.print("\n{f}Option with arguments:{f}\n", .{
             sRec.apply(sConfig.title),
             sRec.reset(),
         });
@@ -190,7 +190,7 @@ pub fn help(self: Self, w: anytype) !void {
     }
 
     if (self.c._stat.posArg != 0) {
-        try w.print("\n{}Positional arguments:{}\n", .{
+        try w.print("\n{f}Positional arguments:{f}\n", .{
             sRec.apply(sConfig.title),
             sRec.reset(),
         });
@@ -201,7 +201,7 @@ pub fn help(self: Self, w: anytype) !void {
     }
 
     if (self.c._stat.cmd != 0) {
-        try w.print("\n{}Commands:{}\n", .{
+        try w.print("\n{f}Commands:{f}\n", .{
             sRec.apply(sConfig.title),
             sRec.reset(),
         });

--- a/src/command/Command.zig
+++ b/src/command/Command.zig
@@ -396,14 +396,14 @@ pub fn parseFrom(self: Self, it: *TokenIter, a_maybe: ?Allocator) Error!self.Res
                     if (hit) {
                         if (matched.pushOnce(a.name) == null) {
                             if ((a.class == .opt and a.T != bool) or (a.class == .optArg and isSlice(a.T))) break;
-                            self.log("match {} again with {}", .{ a, t.opt });
+                            self.log("match {f} again with {f}", .{ a, t.opt });
                             return Error.RepeatOpt;
                         }
                         break;
                     }
                 }
                 if (hit) continue;
-                self.log("unknown option {}", .{t.opt});
+                self.log("unknown option {f}", .{t.opt});
                 return Error.UnknownOpt;
             },
             .posArg, .arg => {
@@ -420,7 +420,7 @@ pub fn parseFrom(self: Self, it: *TokenIter, a_maybe: ?Allocator) Error!self.Res
                 if (a.meta.rawDefault) |s| {
                     @field(r, a.name) = a.parseValue(s, a_maybe) orelse return Error.InvalidOptArg;
                 } else {
-                    self.log("requires {} but not found", .{a});
+                    self.log("requires {f} but not found", .{a});
                     return Error.MissingOptArg;
                 }
             }

--- a/src/command/Config.zig
+++ b/src/command/Config.zig
@@ -181,13 +181,13 @@ pub fn StyleRecord(capacity: comptime_int) type {
                 self.clean = true;
             }
         }
-        pub fn format(self: *Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+        pub fn format(self: *Self, w: *std.io.Writer) std.io.Writer.Error!void {
             switch (self.queue.dequeue().?) {
-                ._apply => |a| try self.format_apply(writer, a),
-                ._reset => try self.format_reset(writer),
+                ._apply => |a| try self.format_apply(w, a),
+                ._reset => try self.format_reset(w),
                 ._restore => |a| {
-                    try self.format_reset(writer);
-                    try self.format_apply(writer, a);
+                    try self.format_reset(w);
+                    try self.format_apply(w, a);
                 },
             }
         }

--- a/src/command/Config.zig
+++ b/src/command/Config.zig
@@ -23,11 +23,11 @@ pub const Prefix = struct {
     short: String = "-",
     /// During matching, the `prefix_long` takes precedence over `prefix_short`.
     long: String = "--",
-    pub fn format(self: @This(), comptime _: []const u8, options: std.fmt.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+    pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
         try writer.writeAll("{ .short = ");
-        try std.fmt.formatBuf(self.short, options, writer);
+        try writer.alignBufferOptions(self.short, .{});
         try writer.writeAll(", .long = ");
-        try std.fmt.formatBuf(self.long, options, writer);
+        try writer.alignBufferOptions(self.long, .{});
         try writer.writeAll(" }");
     }
     pub fn validate(self: *const Self) Error!void {
@@ -65,13 +65,13 @@ pub const Token = struct {
     /// Used as a connector between `singleArgOpt` and its argument.
     connector: String = "=",
 
-    pub fn format(self: Self, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+    pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
         try writer.writeAll("{ .prefix = ");
-        try self.prefix.format(fmt, options, writer);
+        try self.prefix.format(writer);
         try writer.writeAll(", .terminator = ");
-        try std.fmt.formatBuf(self.terminator, options, writer);
+        try writer.alignBufferOptions(self.terminator, .{});
         try writer.writeAll(", .connector = ");
-        try std.fmt.formatBuf(self.connector, options, writer);
+        try writer.alignBufferOptions(self.connector, .{});
         try writer.writeAll(" }");
     }
     pub fn validate(self: *const Self) Error!void {
@@ -104,7 +104,7 @@ pub const Token = struct {
     test "Format Config" {
         try testing.expectEqualStrings(
             "{ .prefix = { .short = -, .long = -- }, .terminator = --, .connector = = }",
-            comptimePrint("{}", .{Self{}}),
+            comptimePrint("{f}", .{Self{}}),
         );
     }
 };
@@ -166,7 +166,7 @@ pub fn StyleRecord(capacity: comptime_int) type {
         clean: bool = true,
         queue: Queue = .{},
         inited: bool = false,
-        fn format_apply(self: *Self, w: anytype, a: Attr) @TypeOf(w).Error!void {
+        fn format_apply(self: *Self, w: *std.io.Writer, a: Attr) std.io.Writer.Error!void {
             if (!std.meta.eql(a, Attr.none)) {
                 if (self.clean) {
                     try Attr.reset.stringify(w);
@@ -175,19 +175,19 @@ pub fn StyleRecord(capacity: comptime_int) type {
                 try a.stringify(w);
             }
         }
-        fn format_reset(self: *Self, w: anytype) @TypeOf(w).Error!void {
+        fn format_reset(self: *Self, w: *std.io.Writer) std.io.Writer.Error!void {
             if (!self.clean) {
                 try Attr.reset.stringify(w);
                 self.clean = true;
             }
         }
-        pub fn format(self: *Self, comptime _: []const u8, _: anytype, w: anytype) @TypeOf(w).Error!void {
+        pub fn format(self: *Self, writer: *std.io.Writer) std.io.Writer.Error!void {
             switch (self.queue.dequeue().?) {
-                ._apply => |a| try self.format_apply(w, a),
-                ._reset => try self.format_reset(w),
+                ._apply => |a| try self.format_apply(writer, a),
+                ._reset => try self.format_reset(writer),
                 ._restore => |a| {
-                    try self.format_reset(w);
-                    try self.format_apply(w, a);
+                    try self.format_reset(writer);
+                    try self.format_apply(writer, a);
                 },
             }
         }
@@ -220,7 +220,7 @@ test StyleRecord {
     var buffer: [64]u8 = undefined;
     try testing.expectEqualStrings(
         "\x1b[0m\x1b[32ma \x1b[4;31mb \x1b[0m\x1b[0m\x1b[3;32ma \x1b[0m hello",
-        try std.fmt.bufPrint(&buffer, "{}a {}b {}a {s} hello", .{
+        try std.fmt.bufPrint(&buffer, "{f}a {f}b {f}a {f} hello", .{
             rec.apply(Attr.none.green()),
             rec.apply(Attr.none.underscore().red()),
             rec.restore(Attr.none.green().italic()),

--- a/src/command/Config.zig
+++ b/src/command/Config.zig
@@ -24,10 +24,11 @@ pub const Prefix = struct {
     /// During matching, the `prefix_long` takes precedence over `prefix_short`.
     long: String = "--",
     pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+        const options: std.fmt.Options = .{};
         try writer.writeAll("{ .short = ");
-        try writer.alignBufferOptions(self.short, .{});
+        try writer.alignBufferOptions(self.short, options);
         try writer.writeAll(", .long = ");
-        try writer.alignBufferOptions(self.long, .{});
+        try writer.alignBufferOptions(self.long, options);
         try writer.writeAll(" }");
     }
     pub fn validate(self: *const Self) Error!void {
@@ -66,12 +67,13 @@ pub const Token = struct {
     connector: String = "=",
 
     pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+        const options: std.fmt.Options = .{};
         try writer.writeAll("{ .prefix = ");
         try self.prefix.format(writer);
         try writer.writeAll(", .terminator = ");
-        try writer.alignBufferOptions(self.terminator, .{});
+        try writer.alignBufferOptions(self.terminator, options);
         try writer.writeAll(", .connector = ");
-        try writer.alignBufferOptions(self.connector, .{});
+        try writer.alignBufferOptions(self.connector, options);
         try writer.writeAll(" }");
     }
     pub fn validate(self: *const Self) Error!void {

--- a/src/command/token.zig
+++ b/src/command/token.zig
@@ -44,6 +44,7 @@ pub const Type = union(enum) {
         /// Long option that follows the prefix_long
         long: String,
         pub fn format(self: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
+            const options: std.fmt.Options = .{};
             try writer.writeAll(@tagName(self));
             try writer.writeAll("<");
             switch (self) {
@@ -51,7 +52,7 @@ pub const Type = union(enum) {
                     try writer.print("{c}", .{s});
                 },
                 .long => |l| {
-                    try writer.alignBufferOptions(l, .{});
+                    try writer.alignBufferOptions(l, options);
                 },
             }
             try writer.writeAll(">");
@@ -76,6 +77,7 @@ pub const Type = union(enum) {
         return .{ .posArg = arg };
     }
     pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+        const options: std.fmt.Options = .{};
         try writer.writeAll(@tagName(self));
         try writer.writeAll("<");
         switch (self) {
@@ -83,7 +85,7 @@ pub const Type = union(enum) {
                 try o.format(writer);
             },
             .optArg, .posArg, .arg => |a| {
-                try writer.alignBufferOptions(a, .{});
+                try writer.alignBufferOptions(a, options);
             },
         }
         try writer.writeAll(">");

--- a/src/command/token.zig
+++ b/src/command/token.zig
@@ -43,15 +43,15 @@ pub const Type = union(enum) {
         short: u8,
         /// Long option that follows the prefix_long
         long: String,
-        pub fn format(self: @This(), comptime _: []const u8, options: std.fmt.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+        pub fn format(self: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
             try writer.writeAll(@tagName(self));
             try writer.writeAll("<");
             switch (self) {
                 .short => |s| {
-                    try std.fmt.format(writer, "{c}", .{s});
+                    try writer.print("{c}", .{s});
                 },
                 .long => |l| {
-                    try std.fmt.formatBuf(l, options, writer);
+                    try writer.alignBufferOptions(l, .{});
                 },
             }
             try writer.writeAll(">");
@@ -75,15 +75,15 @@ pub const Type = union(enum) {
         };
         return .{ .posArg = arg };
     }
-    pub fn format(self: Self, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+    pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
         try writer.writeAll(@tagName(self));
         try writer.writeAll("<");
         switch (self) {
             .opt => |o| {
-                try o.format(fmt, options, writer);
+                try o.format(writer);
             },
             .optArg, .posArg, .arg => |a| {
-                try std.fmt.formatBuf(a, options, writer);
+                try writer.alignBufferOptions(a, .{});
             },
         }
         try writer.writeAll(">");
@@ -228,7 +228,7 @@ const FSM = struct {
                 }
             }
             test "Wrap, FSM, Short" {
-                var it = iter.Wrapper(Short, Error!?Type, "!?").init(Short.init("ac=hello", "="));
+                var it = iter.Wrapper(Short, Error!?Type, "!?f").init(Short.init("ac=hello", "="));
                 it.debug = true;
                 defer it.deinit();
                 try testing.expectEqual('a', (try it.view()).?.opt.short);
@@ -546,7 +546,7 @@ const FSM = struct {
 pub const Iter = struct {
     const Self = @This();
     pub const Error = FSM.Error;
-    const It = iter.Wrapper(FSM.Token, Error!?Type, "!?");
+    const It = iter.Wrapper(FSM.Token, Error!?Type, "!?f");
 
     it: It,
 

--- a/src/helper.zig
+++ b/src/helper.zig
@@ -76,7 +76,7 @@ pub const Collection = struct {
             pub fn is_universal(self: Self) bool {
                 return self.left == null and self.right == null;
             }
-            pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+            fn formatInner(self: Self, writer: *std.io.Writer, comptime fmode: u8, number: ?std.fmt.Number) std.io.Writer.Error!void {
                 const s_empty = "∅";
                 const s_universal = "U";
                 const s_infinity = "∞";
@@ -90,43 +90,23 @@ pub const Collection = struct {
                 }
                 if (self.left) |left| {
                     try writer.writeAll("[");
-                    try any(left, .{}).format(writer);
+                    try any(left, .{}).formatInner(writer, fmode, number);
                 } else {
                     try writer.writeAll(comptimePrint("(-{s}", .{s_infinity}));
                 }
                 try writer.writeAll(",");
                 if (self.right) |right| {
-                    try any(right, .{}).format(writer);
+                    try any(right, .{}).formatInner(writer, fmode, number);
                 } else {
                     try writer.writeAll(s_infinity);
                 }
                 try writer.writeAll(")");
             }
+            pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+                return try self.formatInner(writer, 'f', null);
+            }
             pub fn formatNumber(self: Self, writer: *std.io.Writer, number: std.fmt.Number) std.io.Writer.Error!void {
-                const s_empty = "∅";
-                const s_universal = "U";
-                const s_infinity = "∞";
-                if (self.is_empty()) {
-                    try writer.writeAll(s_empty);
-                    return;
-                }
-                if (self.is_universal()) {
-                    try writer.writeAll(s_universal);
-                    return;
-                }
-                if (self.left) |left| {
-                    try writer.writeAll("[");
-                    try any(left, .{}).formatNumber(writer, number);
-                } else {
-                    try writer.writeAll(comptimePrint("(-{s}", .{s_infinity}));
-                }
-                try writer.writeAll(",");
-                if (self.right) |right| {
-                    try any(right, .{}).formatNumber(writer, number);
-                } else {
-                    try writer.writeAll(s_infinity);
-                }
-                try writer.writeAll(")");
+                return try self.formatInner(writer, 'n', number);
             }
             pub fn contain(self: Self, v: T) bool {
                 if (self.left) |left| {

--- a/src/helper.zig
+++ b/src/helper.zig
@@ -76,7 +76,7 @@ pub const Collection = struct {
             pub fn is_universal(self: Self) bool {
                 return self.left == null and self.right == null;
             }
-            pub fn format(self: Self, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+            pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
                 const s_empty = "∅";
                 const s_universal = "U";
                 const s_infinity = "∞";
@@ -90,13 +90,39 @@ pub const Collection = struct {
                 }
                 if (self.left) |left| {
                     try writer.writeAll("[");
-                    try any(left, .{}).format(fmt, options, writer);
+                    try any(left, .{}).format(writer);
                 } else {
                     try writer.writeAll(comptimePrint("(-{s}", .{s_infinity}));
                 }
                 try writer.writeAll(",");
                 if (self.right) |right| {
-                    try any(right, .{}).format(fmt, options, writer);
+                    try any(right, .{}).format(writer);
+                } else {
+                    try writer.writeAll(s_infinity);
+                }
+                try writer.writeAll(")");
+            }
+            pub fn formatNumber(self: Self, writer: *std.io.Writer, number: std.fmt.Number) std.io.Writer.Error!void {
+                const s_empty = "∅";
+                const s_universal = "U";
+                const s_infinity = "∞";
+                if (self.is_empty()) {
+                    try writer.writeAll(s_empty);
+                    return;
+                }
+                if (self.is_universal()) {
+                    try writer.writeAll(s_universal);
+                    return;
+                }
+                if (self.left) |left| {
+                    try writer.writeAll("[");
+                    try any(left, .{}).formatNumber(writer, number);
+                } else {
+                    try writer.writeAll(comptimePrint("(-{s}", .{s_infinity}));
+                }
+                try writer.writeAll(",");
+                if (self.right) |right| {
+                    try any(right, .{}).formatNumber(writer, number);
                 } else {
                     try writer.writeAll(s_infinity);
                 }
@@ -130,11 +156,11 @@ pub const Collection = struct {
         }
         test "Range format" {
             var buffer: [16]u8 = undefined;
-            try testing.expectEqualStrings("U", try bufPrint(&buffer, "{}", .{Range(u32).universal}));
-            try testing.expectEqualStrings("∅", try bufPrint(&buffer, "{}", .{Range(u32).empty}));
-            try testing.expectEqualStrings("(-∞,1)", try bufPrint(&buffer, "{}", .{comptime Range(i32).init(null, 1)}));
-            try testing.expectEqualStrings("[-1,1)", try bufPrint(&buffer, "{}", .{comptime Range(i32).init(-1, 1)}));
-            try testing.expectEqualStrings("[-1,∞)", try bufPrint(&buffer, "{}", .{comptime Range(i32).init(-1, null)}));
+            try testing.expectEqualStrings("U", try bufPrint(&buffer, "{f}", .{Range(u32).universal}));
+            try testing.expectEqualStrings("∅", try bufPrint(&buffer, "{f}", .{Range(u32).empty}));
+            try testing.expectEqualStrings("(-∞,1)", try bufPrint(&buffer, "{f}", .{comptime Range(i32).init(null, 1)}));
+            try testing.expectEqualStrings("[-1,1)", try bufPrint(&buffer, "{f}", .{comptime Range(i32).init(-1, 1)}));
+            try testing.expectEqualStrings("[-1,∞)", try bufPrint(&buffer, "{f}", .{comptime Range(i32).init(-1, null)}));
             try testing.expectEqualStrings("[  -f,  +c)", try bufPrint(&buffer, "{x:>4}", .{comptime Range(i32).init(-0xf, 0xc)}));
         }
         test "Range contain" {
@@ -319,16 +345,16 @@ pub const Compare = struct {
 };
 
 pub fn exit(catched: anyerror, status: u8) noreturn {
-    const stderr = std.io.getStdErr().writer();
-    stderr.print("catch: {any}\n", .{catched}) catch unreachable;
+    var stderr = std.fs.File.stderr().writer(&@as([0]u8, .{}));
+    stderr.interface.print("catch: {any}\n", .{catched}) catch unreachable;
     std.process.exit(status);
 }
 
 pub fn exitf(catched: ?anyerror, status: u8, comptime fmt: String, args: anytype) noreturn {
-    const stderr = std.io.getStdErr().writer();
+    var stderr = std.fs.File.stderr().writer(&@as([0]u8, .{}));
     if (catched) |e|
-        stderr.print("catch: {any}\n", .{e}) catch unreachable;
-    stderr.print(fmt ++ "\n", args) catch unreachable;
+        stderr.interface.print("catch: {any}\n", .{e}) catch unreachable;
+    stderr.interface.print(fmt ++ "\n", args) catch unreachable;
     std.process.exit(status);
 }
 

--- a/src/io/fmt.zig
+++ b/src/io/fmt.zig
@@ -40,18 +40,24 @@ pub fn Any(V: type) type {
         pub fn init(value: V, options: Options) Self {
             return .{ .value = value, .options = options };
         }
-        pub fn formatInner(self: Self, writer: *std.io.Writer, comptime fmode: u8) std.io.Writer.Error!void {
+        pub fn formatInner(self: Self, writer: *std.io.Writer, comptime fmode: u8, number: ?std.fmt.Number) std.io.Writer.Error!void {
+            const options: std.fmt.Options = if (number) |num| .{
+                .alignment = num.alignment,
+                .fill = num.fill,
+                .precision = num.precision,
+                .width = num.width,
+            } else .{};
             if (comptime checker.isOptional(V)) {
                 if (self.value) |v| {
-                    try any(v, self.options).formatInner(writer, fmode);
+                    try any(v, self.options).formatInner(writer, fmode, number);
                 } else {
-                    if (self.options.optional.show_null) try writer.alignBufferOptions("null", .{});
+                    if (self.options.optional.show_null) try writer.alignBufferOptions("null", options);
                 }
                 return;
             }
             if (V == LiteralString or V == String) {
                 if (fmode == 's' or fmode == 'f') {
-                    try writer.alignBufferOptions(self.value, .{});
+                    try writer.alignBufferOptions(self.value, options);
                     return;
                 }
             }
@@ -61,60 +67,29 @@ pub fn Any(V: type) type {
                 for (self.value, 0..) |v, i| {
                     if (i != 0 and i % self.options.multiple.groupSize == 0)
                         try writer.alignBufferOptions(self.options.multiple.separator, .{});
-                    try any(v, self.options).formatInner(writer, fmode);
+                    try any(v, self.options).formatInner(writer, fmode, number);
                 }
                 try writer.alignBufferOptions(self.options.multiple.end, .{});
                 return;
             }
             if (V == u8 and fmode == 'c') {
-                return writer.printAsciiChar(self.value, .{});
+                return writer.printAsciiChar(self.value, options);
             }
             if (comptime checker.isBase(V) and fmode == 'f') {
                 switch (@typeInfo(V)) {
-                    .@"enum" => try writer.alignBufferOptions(@tagName(self.value), .{}),
+                    .@"enum" => try writer.alignBufferOptions(@tagName(self.value), options),
                     else => {
                         if (std.meta.hasMethod(V, "format")) {
                             try self.value.format(writer);
                         } else {
-                            try writer.printValue("", .{}, self.value, std.options.fmt_max_depth);
+                            try writer.printValue("", options, self.value, std.options.fmt_max_depth);
                         }
                     },
                 }
                 return;
             }
-            @compileError(comptimePrint("Unable to format {s}", .{@typeName(V)}));
-        }
-        pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
-            return self.formatInner(writer, 'f');
-        }
-        pub fn formatNumber(self: Self, writer: *std.io.Writer, number: std.fmt.Number) std.io.Writer.Error!void {
-            const options: std.fmt.Options = .{
-                .alignment = number.alignment,
-                .fill = number.fill,
-                .precision = number.precision,
-                .width = number.width,
-            };
-            @setEvalBranchQuota(5000);
-            if (comptime checker.isOptional(V)) {
-                if (self.value) |v| {
-                    try any(v, self.options).formatNumber(writer, number);
-                } else {
-                    if (self.options.optional.show_null) try writer.alignBufferOptions("null", .{});
-                }
-                return;
-            }
-            if (comptime checker.isMultiple(V) or V == LiteralString or V == String) {
-                self.options.assert();
-                try writer.alignBufferOptions(self.options.multiple.begin, options);
-                for (self.value, 0..) |v, i| {
-                    if (i != 0 and i % self.options.multiple.groupSize == 0)
-                        try writer.alignBufferOptions(self.options.multiple.separator, options);
-                    try any(v, self.options).formatNumber(writer, number);
-                }
-                try writer.alignBufferOptions(self.options.multiple.end, options);
-                return;
-            } else {
-                switch (number.mode) {
+            if (fmode == 'n') {
+                switch (number.?.mode) {
                     .decimal => switch (@typeInfo(@TypeOf(self.value))) {
                         .float, .comptime_float, .int, .comptime_int, .@"struct", .@"enum", .vector => {
                             try writer.printValue("d", options, self.value, std.options.fmt_max_depth);
@@ -135,7 +110,7 @@ pub fn Any(V: type) type {
                     },
                     .hex => switch (@typeInfo(@TypeOf(self.value))) {
                         .float, .comptime_float, .int, .comptime_int, .@"enum", .@"struct", .pointer, .vector => {
-                            switch (number.case) {
+                            switch (number.?.case) {
                                 .lower => try writer.printValue("x", options, self.value, std.options.fmt_max_depth),
                                 .upper => try writer.printValue("X", options, self.value, std.options.fmt_max_depth),
                             }
@@ -144,7 +119,7 @@ pub fn Any(V: type) type {
                     },
                     .scientific => switch (@typeInfo(@TypeOf(self.value))) {
                         .float, .comptime_float, .@"struct" => {
-                            switch (number.case) {
+                            switch (number.?.case) {
                                 .lower => try writer.printValue("e", options, self.value, std.options.fmt_max_depth),
                                 .upper => try writer.printValue("E", options, self.value, std.options.fmt_max_depth),
                             }
@@ -152,13 +127,22 @@ pub fn Any(V: type) type {
                         else => unreachable,
                     },
                 }
+                return;
             }
+            @compileError(comptimePrint("Unable to format {s}", .{@typeName(V)}));
+        }
+        pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+            return self.formatInner(writer, 'f', null);
+        }
+        pub fn formatNumber(self: Self, writer: *std.io.Writer, number: std.fmt.Number) std.io.Writer.Error!void {
+            @setEvalBranchQuota(5000);
+            return self.formatInner(writer, 'n', number);
         }
         pub fn formatString(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
-            return self.formatInner(writer, 's');
+            return self.formatInner(writer, 's', null);
         }
         pub fn formatChar(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
-            return self.formatInner(writer, 'c');
+            return self.formatInner(writer, 'c', null);
         }
     };
 }

--- a/src/io/fmt.zig
+++ b/src/io/fmt.zig
@@ -226,8 +226,7 @@ test "Base" {
     }
     {
         const Person = struct { age: u32, name: String };
-        // The standard printing behavior of structures in `std` has changed.
-        // To restore the original behavior, a possible solution is to copy the implementation of `formatType` from the old standard library.
+        // NOTE: The standard printing behavior of structures in `std` has changed in 0.15.1.
         // const expect = "Person{ .age = 18, .name = { 74, 97, 99, 107 } }";
         const expect = ".{ .age = 18, .name = { 74, 97, 99, 107 } }";
         try testing.expect(std.mem.endsWith(

--- a/src/io/fmt.zig
+++ b/src/io/fmt.zig
@@ -40,40 +40,125 @@ pub fn Any(V: type) type {
         pub fn init(value: V, options: Options) Self {
             return .{ .value = value, .options = options };
         }
-        pub fn format(self: Self, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+        pub fn formatInner(self: Self, writer: *std.io.Writer, comptime fmode: u8) std.io.Writer.Error!void {
             if (comptime checker.isOptional(V)) {
                 if (self.value) |v| {
-                    try any(v, self.options).format(fmt, options, writer);
+                    try any(v, self.options).formatInner(writer, fmode);
                 } else {
-                    if (self.options.optional.show_null) try std.fmt.formatBuf("null", options, writer);
+                    if (self.options.optional.show_null) try writer.alignBufferOptions("null", .{});
                 }
                 return;
             }
             if (V == LiteralString or V == String) {
-                if (fmt.len == 0 or comptime std.mem.eql(u8, fmt, "s")) {
-                    try std.fmt.formatBuf(self.value, options, writer);
+                if (fmode == 's' or fmode == 'f') {
+                    try writer.alignBufferOptions(self.value, .{});
                     return;
                 }
             }
             if (comptime checker.isMultiple(V) or V == LiteralString or V == String) {
                 self.options.assert();
-                try std.fmt.formatBuf(self.options.multiple.begin, .{}, writer);
+                try writer.alignBufferOptions(self.options.multiple.begin, .{});
                 for (self.value, 0..) |v, i| {
                     if (i != 0 and i % self.options.multiple.groupSize == 0)
-                        try std.fmt.formatBuf(self.options.multiple.separator, .{}, writer);
-                    try any(v, self.options).format(fmt, options, writer);
+                        try writer.alignBufferOptions(self.options.multiple.separator, .{});
+                    try any(v, self.options).formatInner(writer, fmode);
                 }
-                try std.fmt.formatBuf(self.options.multiple.end, .{}, writer);
+                try writer.alignBufferOptions(self.options.multiple.end, .{});
                 return;
             }
-            if (comptime checker.isBase(V)) {
+            if (V == u8 and fmode == 'c') {
+                return writer.printAsciiChar(self.value, .{});
+            }
+            if (comptime checker.isBase(V) and fmode == 'f') {
                 switch (@typeInfo(V)) {
-                    .@"enum" => try std.fmt.formatBuf(@tagName(self.value), options, writer),
-                    else => try std.fmt.formatType(self.value, fmt, options, writer, std.options.fmt_max_depth),
+                    .@"enum" => try writer.alignBufferOptions(@tagName(self.value), .{}),
+                    else => {
+                        if (std.meta.hasMethod(V, "format")) {
+                            try self.value.format(writer);
+                        } else {
+                            try writer.printValue("", .{}, self.value, std.options.fmt_max_depth);
+                        }
+                    },
                 }
                 return;
             }
             @compileError(comptimePrint("Unable to format {s}", .{@typeName(V)}));
+        }
+        pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+            return self.formatInner(writer, 'f');
+        }
+        pub fn formatNumber(self: Self, writer: *std.io.Writer, number: std.fmt.Number) std.io.Writer.Error!void {
+            const options: std.fmt.Options = .{
+                .alignment = number.alignment,
+                .fill = number.fill,
+                .precision = number.precision,
+                .width = number.width,
+            };
+            @setEvalBranchQuota(5000);
+            if (comptime checker.isOptional(V)) {
+                if (self.value) |v| {
+                    try any(v, self.options).formatNumber(writer, number);
+                } else {
+                    if (self.options.optional.show_null) try writer.alignBufferOptions("null", .{});
+                }
+                return;
+            }
+            if (comptime checker.isMultiple(V) or V == LiteralString or V == String) {
+                self.options.assert();
+                try writer.alignBufferOptions(self.options.multiple.begin, options);
+                for (self.value, 0..) |v, i| {
+                    if (i != 0 and i % self.options.multiple.groupSize == 0)
+                        try writer.alignBufferOptions(self.options.multiple.separator, options);
+                    try any(v, self.options).formatNumber(writer, number);
+                }
+                try writer.alignBufferOptions(self.options.multiple.end, options);
+                return;
+            } else {
+                switch (number.mode) {
+                    .decimal => switch (@typeInfo(@TypeOf(self.value))) {
+                        .float, .comptime_float, .int, .comptime_int, .@"struct", .@"enum", .vector => {
+                            try writer.printValue("d", options, self.value, std.options.fmt_max_depth);
+                        },
+                        else => unreachable,
+                    },
+                    .binary => switch (@typeInfo(@TypeOf(self.value))) {
+                        .int, .comptime_int, .@"enum", .@"struct", .vector => {
+                            try writer.printValue("b", options, self.value, std.options.fmt_max_depth);
+                        },
+                        else => unreachable,
+                    },
+                    .octal => switch (@typeInfo(@TypeOf(self.value))) {
+                        .int, .comptime_int, .@"enum", .@"struct", .vector => {
+                            try writer.printValue("o", options, self.value, std.options.fmt_max_depth);
+                        },
+                        else => unreachable,
+                    },
+                    .hex => switch (@typeInfo(@TypeOf(self.value))) {
+                        .float, .comptime_float, .int, .comptime_int, .@"enum", .@"struct", .pointer, .vector => {
+                            switch (number.case) {
+                                .lower => try writer.printValue("x", options, self.value, std.options.fmt_max_depth),
+                                .upper => try writer.printValue("X", options, self.value, std.options.fmt_max_depth),
+                            }
+                        },
+                        else => unreachable,
+                    },
+                    .scientific => switch (@typeInfo(@TypeOf(self.value))) {
+                        .float, .comptime_float, .@"struct" => {
+                            switch (number.case) {
+                                .lower => try writer.printValue("e", options, self.value, std.options.fmt_max_depth),
+                                .upper => try writer.printValue("E", options, self.value, std.options.fmt_max_depth),
+                            }
+                        },
+                        else => unreachable,
+                    },
+                }
+            }
+        }
+        pub fn formatString(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+            return self.formatInner(writer, 's');
+        }
+        pub fn formatChar(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
+            return self.formatInner(writer, 'c');
         }
     };
 }
@@ -86,19 +171,19 @@ pub fn Stringify(V: type, method: LiteralString) type {
     return struct {
         v: V,
         pub fn count(self: @This()) usize {
-            var writer = std.io.countingWriter(std.io.null_writer);
+            var counting = std.Io.Writer.Discarding.init(&@as([0]u8, .{}));
             @setEvalBranchQuota(100000); // TODO why?
             // or use `@field(Cls, fname)(obj, args...)` directly
-            @call(.auto, @field(V, method), .{ self.v, writer.writer() }) catch unreachable;
-            return writer.bytes_written;
+            @call(.auto, @field(V, method), .{ self.v, &counting.writer }) catch unreachable;
+            return counting.fullCount();
         }
         pub inline fn literal(self: @This()) *const [self.count():0]u8 {
             comptime {
                 var buf: [self.count():0]u8 = undefined;
-                var fbs = std.io.fixedBufferStream(&buf);
-                @setEvalBranchQuota(100000); // TODO why?
-                // @call(.auto, @field(V, method), .{ self.v, fbs.writer() }) catch unreachable;
-                @field(V, method)(self.v, fbs.writer()) catch unreachable;
+                var fbs = std.Io.Writer.fixed(&buf);
+                @setEvalBranchQuota(1000000); // TODO why?
+                // @call(.auto, @field(V, method), .{ self.v, &fbs }) catch unreachable;
+                @field(V, method)(self.v, &fbs) catch unreachable;
                 buf[buf.len] = 0;
                 const final = buf;
                 return &final;
@@ -121,46 +206,49 @@ const testing = std.testing;
 test "Base" {
     {
         var buffer: [64]u8 = undefined;
-        try testing.expectEqualStrings("1", try bufPrint(&buffer, "{}", .{Any(u32).init(1, .{})}));
-        try testing.expectEqualStrings("9.000e-1", try bufPrint(&buffer, "{:.3}", .{Any(f32).init(0.9, .{})}));
-        try testing.expectEqualStrings("true", try bufPrint(&buffer, "{}", .{Any(bool).init(true, .{})}));
-        try testing.expectEqualStrings("1", comptimePrint("{}", .{comptime Any(u32).init(1, .{})}));
+        try testing.expectEqualStrings("1", try bufPrint(&buffer, "{f}", .{Any(u32).init(1, .{})}));
+        try testing.expectEqualStrings("9.000e-1", try bufPrint(&buffer, "{e:.3}", .{Any(f32).init(0.9, .{})}));
+        try testing.expectEqualStrings("true", try bufPrint(&buffer, "{f}", .{Any(bool).init(true, .{})}));
+        try testing.expectEqualStrings("1", comptimePrint("{f}", .{comptime Any(u32).init(1, .{})}));
         {
             const ab = [_]u8{ 'a', 'b' };
-            try testing.expectEqualStrings("{ a, b }", comptimePrint("{c}", .{comptime Any([2]u8).init(ab, .{})}));
-            try testing.expectEqualStrings("{ a, b }", comptimePrint("{c}", .{comptime any(ab, .{})}));
-            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{c}", .{Any([2]u8).init(ab, .{})}));
-            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{c}", .{any(ab, .{})}));
-            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{c}", .{Any([]const u8).init(&ab, .{})}));
-            try testing.expectEqualStrings("ab", try bufPrint(&buffer, "{s}", .{Any([]const u8).init(&ab, .{})}));
-            try testing.expectEqualStrings("ab", try bufPrint(&buffer, "{s}", .{any(@as([]const u8, &ab), .{})}));
-            try testing.expectEqualStrings("ab", try bufPrint(&buffer, "{}", .{any(@as([]const u8, &ab), .{})}));
+            try testing.expectEqualStrings("{ a, b }", comptimePrint("{f}", .{comptime std.fmt.alt(Any([2]u8).init(ab, .{}), .formatChar)}));
+            try testing.expectEqualStrings("{ a, b }", comptimePrint("{f}", .{comptime std.fmt.alt(any(ab, .{}), .formatChar)}));
+            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any([2]u8).init(ab, .{}), .formatChar)}));
+            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(any(ab, .{}), .formatChar)}));
+            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any([]const u8).init(&ab, .{}), .formatChar)}));
+            try testing.expectEqualStrings("ab", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any([]const u8).init(&ab, .{}), .formatString)}));
+            try testing.expectEqualStrings("ab", try bufPrint(&buffer, "{f}", .{std.fmt.alt(any(@as([]const u8, &ab), .{}), .formatString)}));
+            try testing.expectEqualStrings("ab", try bufPrint(&buffer, "{f}", .{any(@as([]const u8, &ab), .{})}));
         }
         {
             var ab = [_]u8{ 'a', 'b' };
-            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{c}", .{Any([]u8).init(&ab, .{})}));
-            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{c}", .{Any([2]u8).init(ab, .{})}));
+            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any([]u8).init(&ab, .{}), .formatChar)}));
+            try testing.expectEqualStrings("{ a, b }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any([2]u8).init(ab, .{}), .formatChar)}));
         }
         {
             const s: [:0]const u8 = "hello";
-            try testing.expectEqualStrings("{ h, e, l, l, o }", try bufPrint(&buffer, "{c}", .{any(s, .{})}));
-            try testing.expectEqualStrings("hello", try bufPrint(&buffer, "{s}", .{any(s, .{})}));
-            try testing.expectEqualStrings("hello", try bufPrint(&buffer, "{}", .{any(s, .{})}));
+            try testing.expectEqualStrings("{ h, e, l, l, o }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(any(s, .{}), .formatChar)}));
+            try testing.expectEqualStrings("hello", try bufPrint(&buffer, "{f}", .{std.fmt.alt(any(s, .{}), .formatString)}));
+            try testing.expectEqualStrings("hello", try bufPrint(&buffer, "{f}", .{any(s, .{})}));
         }
     }
     {
         const Color = enum { Red, Green, Blue };
         try testing.expectEqualStrings(
             "Green",
-            comptimePrint("{}", .{comptime Any(Color).init(.Green, .{})}),
+            comptimePrint("{f}", .{comptime Any(Color).init(.Green, .{})}),
         );
     }
     {
         const Person = struct { age: u32, name: String };
-        const expect = "Person{ .age = 18, .name = { 74, 97, 99, 107 } }";
+        // The standard printing behavior of structures in `std` has changed.
+        // To restore the original behavior, a possible solution is to copy the implementation of `formatType` from the old standard library.
+        // const expect = "Person{ .age = 18, .name = { 74, 97, 99, 107 } }";
+        const expect = ".{ .age = 18, .name = { 74, 97, 99, 107 } }";
         try testing.expect(std.mem.endsWith(
             u8,
-            comptimePrint("{}", .{comptime Any(Person).init(.{ .age = 18, .name = "Jack" }, .{})}),
+            comptimePrint("{f}", .{comptime Any(Person).init(.{ .age = 18, .name = "Jack" }, .{})}),
             expect,
         ));
     }
@@ -168,31 +256,36 @@ test "Base" {
 
 test "Optional" {
     var buffer: [16]u8 = undefined;
-    try testing.expectEqualStrings("1", try bufPrint(&buffer, "{}", .{Any(?u32).init(1, .{})}));
+    try testing.expectEqualStrings("1", try bufPrint(&buffer, "{f}", .{Any(?u32).init(1, .{})}));
     try testing.expectEqualStrings("f", try bufPrint(&buffer, "{x}", .{Any(?u32).init(0xf, .{})}));
     try testing.expectEqualStrings("##f", try bufPrint(&buffer, "{x:#>3}", .{Any(?u32).init(0xf, .{})}));
-    try testing.expectEqualStrings("null", try bufPrint(&buffer, "{}", .{Any(?u32).init(null, .{})}));
-    try testing.expectEqualStrings("", try bufPrint(&buffer, "{}", .{Any(?u32).init(null, .{ .optional = .{ .show_null = false } })}));
-    try testing.expectEqualStrings(" hello", try bufPrint(&buffer, "{s:>6}", .{Any(?String).init("hello", .{})}));
-    try testing.expectEqualStrings("1", comptimePrint("{}", .{comptime Any(?u32).init(1, .{})}));
+    try testing.expectEqualStrings("null", try bufPrint(&buffer, "{f}", .{Any(?u32).init(null, .{})}));
+    try testing.expectEqualStrings("", try bufPrint(&buffer, "{f}", .{Any(?u32).init(null, .{ .optional = .{ .show_null = false } })}));
+    // Custom `format` with formatting options is no longer supported in zig 0.15.1, and no replacement has been found.
+    // A possible alternative for this requirement is a dedicated function that converts `Any` to `[]const u8`, specifying formatting options.
+    // try testing.expectEqualStrings(" hello", try bufPrint(&buffer, "{s:>6}", .{Any(?String).init("hello", .{})}));
+    try testing.expectEqualStrings("hello", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any(?String).init("hello", .{}), .formatString)}));
+    try testing.expectEqualStrings("1", comptimePrint("{f}", .{comptime Any(?u32).init(1, .{})}));
 }
 
 test "Multiple" {
     try testing.expectEqualStrings(
         "{  }",
-        comptimePrint("{s}", .{comptime Any([]String).init(&[_]String{}, .{})}),
+        comptimePrint("{f}", .{comptime std.fmt.alt(Any([]String).init(&[_]String{}, .{}), .formatString)}),
     );
     try testing.expectEqualStrings(
         "{ hello, world }",
-        comptimePrint("{s}", .{comptime Any([]const String).init(&[_]String{ "hello", "world" }, .{})}),
+        comptimePrint("{f}", .{comptime std.fmt.alt(Any([]const String).init(&[_]String{ "hello", "world" }, .{}), .formatString)}),
     );
-    try testing.expectEqualStrings(
-        "{ _hello, _world }",
-        comptimePrint("{s:_>6}", .{comptime Any([2]String).init([_]String{ "hello", "world" }, .{})}),
-    );
+    // Custom `format` with formatting options is no longer supported in zig 0.15.1, and no replacement has been found.
+    // A possible alternative for this requirement is a dedicated function that converts `Any` to `[]const u8`, specifying formatting options.
+    // try testing.expectEqualStrings(
+    //     "{ _hello, _world }",
+    //     comptimePrint("{s:_>6}", .{comptime Any([2]String).init([_]String{ "hello", "world" }, .{})}),
+    // );
     try testing.expectEqualStrings(
         "{ 15, 192 }",
-        comptimePrint("{}", .{comptime Any([]const i32).init(&[_]i32{ 0xf, 0xc0 }, .{})}),
+        comptimePrint("{f}", .{comptime Any([]const i32).init(&[_]i32{ 0xf, 0xc0 }, .{})}),
     );
     try testing.expectEqualStrings(
         "{ 0f, c0 }",
@@ -201,10 +294,10 @@ test "Multiple" {
     {
         var buffer: [64]u8 = undefined;
         var ab = [_]LiteralString{ "hello", "world" };
-        try testing.expectEqualStrings("{ { h, e, l, l, o }, { w, o, r, l, d } }", try bufPrint(&buffer, "{c}", .{Any([]LiteralString).init(&ab, .{})}));
-        try testing.expectEqualStrings("{ { h, e, l, l, o }, { w, o, r, l, d } }", try bufPrint(&buffer, "{c}", .{Any([2]LiteralString).init(ab, .{})}));
-        try testing.expectEqualStrings("{ hello, world }", try bufPrint(&buffer, "{s}", .{Any([]LiteralString).init(&ab, .{})}));
-        try testing.expectEqualStrings("{ hello, world }", try bufPrint(&buffer, "{s}", .{Any([2]LiteralString).init(ab, .{})}));
+        try testing.expectEqualStrings("{ { h, e, l, l, o }, { w, o, r, l, d } }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any([]LiteralString).init(&ab, .{}), .formatChar)}));
+        try testing.expectEqualStrings("{ { h, e, l, l, o }, { w, o, r, l, d } }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any([2]LiteralString).init(ab, .{}), .formatChar)}));
+        try testing.expectEqualStrings("{ hello, world }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any([]LiteralString).init(&ab, .{}), .formatString)}));
+        try testing.expectEqualStrings("{ hello, world }", try bufPrint(&buffer, "{f}", .{std.fmt.alt(Any([2]LiteralString).init(ab, .{}), .formatString)}));
     }
 }
 

--- a/src/iter.zig
+++ b/src/iter.zig
@@ -47,7 +47,7 @@ pub fn Wrapper(I: type, R: type, specifier: ?[]const u8) type {
                 s = "";
             }
             const item = self.cache.?;
-            self.log("\x1b[92mview\x1b[90m{s}\x1b[0m {" ++ (specifier orelse "") ++ "}\n", .{ s, item });
+            self.log("\x1b[92mview\x1b[90m{s}\x1b[0m {" ++ (specifier orelse "f") ++ "}\n", .{ s, item });
             return item;
         }
         pub fn init(it: I) Self {
@@ -61,12 +61,12 @@ pub fn Wrapper(I: type, R: type, specifier: ?[]const u8) type {
         }
         /// Complete the remaining iteration.
         pub fn nextAll(self: *Self, allocator: std.mem.Allocator) ![]const BaseR {
-            var items = std.ArrayList(BaseR).init(allocator);
-            defer items.deinit();
+            var items: std.ArrayList(BaseR) = .empty;
+            defer items.deinit(allocator);
             while (if (is_ErrorUnion) (try self.next()) else self.next()) |item| {
-                try items.append(item);
+                try items.append(allocator, item);
             }
-            return try items.toOwnedSlice();
+            return try items.toOwnedSlice(allocator);
         }
     };
 }

--- a/src/type/open.zig
+++ b/src/type/open.zig
@@ -36,15 +36,15 @@ fn OpenFn(openType: OpenType, lazy: bool, flags: OpenFlags(openType)) type {
             switch (openType) {
                 .file => if ((comptime flags.mode != .read_write) and std.mem.eql(u8, s, "-")) {
                     self.v = switch (flags.mode) {
-                        .read_only => std.io.getStdIn(),
-                        .write_only => std.io.getStdOut(),
+                        .read_only => std.fs.File.stdin(),
+                        .write_only => std.fs.File.stdout(),
                         else => unreachable,
                     };
                     self.@".is_stdio" = true;
                     self.@".is_inited" = true;
                 },
                 .fileCreate => if ((comptime !flags.read) and std.mem.eql(u8, s, "-")) {
-                    self.v = std.io.getStdOut();
+                    self.v = std.fs.File.stdout();
                     self.@".is_stdio" = true;
                     self.@".is_inited" = true;
                 },
@@ -70,7 +70,7 @@ fn OpenFn(openType: OpenType, lazy: bool, flags: OpenFlags(openType)) type {
             if (!self.@".is_stdio" and self.@".is_inited") self.v.close();
             if (a_maybe) |a| a.free(self.s);
         }
-        pub fn format(self: Self, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+        pub fn format(self: Self, writer: *std.io.Writer) std.io.Writer.Error!void {
             try writer.print("{s}({s})", .{ @tagName(openType), self.s });
         }
     };

--- a/src/type/read.zig
+++ b/src/type/read.zig
@@ -24,7 +24,7 @@ fn ReadFn(lazy: bool) type {
         }
         pub fn unlazy(self: *Self, a_maybe: ?std.mem.Allocator) !String {
             if (!self.@".is_inited") {
-                var fp = if (std.mem.eql(u8, self.s, "-")) std.io.getStdIn() else try std.fs.cwd().openFile(self.s, .{});
+                var fp = if (std.mem.eql(u8, self.s, "-")) std.fs.File.stdin() else try std.fs.cwd().openFile(self.s, .{});
                 defer fp.close();
                 self.v = try fp.readToEndAlloc(a_maybe.?, 4 << 10);
                 self.@".is_inited" = true;


### PR DESCRIPTION
Currently all tests pass (Removed two tests that could not be restored, changed the expected result of a test, and changed the usage of several tests to workarounds). The log output to stderr is generally the same as in the previous version, but there are some differences due to changes in the default structure printing behavior.

Due to changes in how formatted strings are handled in zig 0.15.1, testing for adding formatting options for non-numeric printing is permanently broken, and there's no low-cost workaround.

Furthermore, changes to zig's default formatting for structure printing have forced some tests to modify their expected results. This change primarily affects logging results. To restore the original behavior, a future workaround might involve copying the zig standard library code from an older version.

The `stderr` writer now allows for a buffer. For simplicity, the unbuffered writer is still used.