### PR TITLE
Fix:[CI] 修复badge正确逻辑

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - ci-test/*
+      - main
 
   workflow_dispatch:
 
@@ -68,7 +69,7 @@ jobs:
           echo "COLOR=$COLOR" >> $GITHUB_ENV
 
       - name: Update badge
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}


### PR DESCRIPTION
CI应当在push到main分支时触发，而且仅当push到main分支时才应当更新badge。
现在，仅仅提交PR触发的CI不会再更新badge了
为了测试CI本身而在push到`ci-test/*`分支时更新badge也可以视作合理行为，所以没有限制push到`main`以外分支时的更新badge行为触发。